### PR TITLE
Feature: Incorporates a test for persistent storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ RUN go get github.com/joho/godotenv
 
 RUN go build && chmod +x ./internal-services-test
 
-ENV SOLR_HOST=solr \
-    REDIS_HOST=redis \
-    OPENSEARCH_HOST=opensearch-2
+ENV STORAGE_LOCATION='/app/files'
 
 EXPOSE 3000
 

--- a/TESTING_dockercompose.md
+++ b/TESTING_dockercompose.md
@@ -76,6 +76,10 @@ docker compose exec -T commons sh -c "curl -kL http://go-web:3000/solr?service=s
 # solr-8 should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/solr?service=solr-8" | grep "SERVICE_HOST=solr-8"
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/solr?service=solr-8" | grep "LAGOON_TEST_VAR=internal-services-test"
+
+# persistent storage should be able to read/write data
+docker compose exec -T commons sh -c "curl -kL http://go-web:3000/storage?path=/app/files" | grep "STORAGE_PATH=/app/files/storage.txt"
+docker compose exec -T commons sh -c "curl -kL http://go-web:3000/storage?path=/app/files" | grep "LAGOON_TEST_VAR=internal-services-test"
 ```
 
 Destroy tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   solr-7-data:
   solr-8-data:
   opensearch-2-data:
+  scratch:
 
 services:
   web:
@@ -11,7 +12,7 @@ services:
       context: .
       dockerfile: Dockerfile
     labels:
-      lagoon.type: basic
+      lagoon.type: basic-persistent
     ports:
       - '3000:3000'
     container_name: go-web
@@ -19,6 +20,9 @@ services:
       - LAGOON_TEST_VAR=internal-services-test
       - LAGOON_GIT_SHA=SHA256
       - LAGOON_ENVIRONMENT_TYPE=development
+      - STORAGE_LOCATION=/app/files
+    volumes:
+      - scratch:/app/files
 
   mariadb-10-5:
     image: uselagoon/mariadb-10.5:latest

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/redis/go-redis/v9 v9.3.0
+	github.com/uselagoon/machinery v0.0.12
 	github.com/vanng822/go-solr v0.10.0
 	go.mongodb.org/mongo-driver v1.12.1
 )

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,9 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -56,6 +57,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/uselagoon/machinery v0.0.12 h1:TJnA+FrL1uEhRTjJ6dExiL4G7SOQ+hUfGuWDmbW2HBA=
+github.com/uselagoon/machinery v0.0.12/go.mod h1:h/qeMWQR4Qqu33x+8AulNDeolEwvb/G+aIsn/jyUtwk=
 github.com/vanng822/go-solr v0.10.0 h1:oygAxyFL2apSN8vddxDXoyho40z66Guu9nwH7ANr6wM=
 github.com/vanng822/go-solr v0.10.0/go.mod h1:FSglzTPzoNVKTXP+SqEQiiz284cKzcKpeRXmwPa81wc=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
@@ -115,7 +118,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type funcType func() map[string]string

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	r.HandleFunc("/solr", solrHandler)
 	r.HandleFunc("/mongo", mongoHandler)
 	r.HandleFunc("/opensearch", opensearchHandler)
+	r.HandleFunc("/storage", persistentStorageHandler)
 	r.HandleFunc("/", handleReq)
 	http.Handle("/", r)
 

--- a/main.go
+++ b/main.go
@@ -6,13 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
-	"os"
 	"strings"
-	"time"
-)
-
-var (
-	localCheck = os.Getenv("LAGOON_ENVIRONMENT")
 )
 
 type funcType func() map[string]string
@@ -76,13 +70,4 @@ func cleanRoute(basePath string) (string, string) {
 	replaceHyphen := strings.ReplaceAll(localService, "-", "_")
 	lagoonService := strings.ToUpper(replaceHyphen)
 	return localService, lagoonService
-}
-
-// getEnv get key environment variable if exist otherwise return defalutValue
-func getEnv(key, defaultValue string) string {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return defaultValue
-	}
-	return value
 }

--- a/mariadb.go
+++ b/mariadb.go
@@ -3,7 +3,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
+	machineryEnvVars "github.com/uselagoon/machinery/utils/variables"
 	"log"
 	"net/http"
 	"os"
@@ -16,13 +16,13 @@ var (
 )
 
 func mariadbHandler(w http.ResponseWriter, r *http.Request) {
-	service := r.URL.Query().Get("service")
-	localService, lagoonService := cleanRoute(service)
-	mariadbUser := getEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
-	mariadbPassword := getEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
-	mariadbHost := getEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)
-	mariadbPort := getEnv(fmt.Sprintf("%s_PORT", lagoonService), "3306")
-	mariadbDatabase := getEnv(fmt.Sprintf("%s_DATABASE", lagoonService), "lagoon")
+	mariadbPath := r.URL.Path
+	localService, lagoonService := cleanRoute(mariadbPath)
+	mariadbUser := machineryEnvVars.GetEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
+	mariadbPassword := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
+	mariadbHost := machineryEnvVars.GetEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)
+	mariadbPort := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PORT", lagoonService), "3306")
+	mariadbDatabase := machineryEnvVars.GetEnv(fmt.Sprintf("%s_DATABASE", lagoonService), "lagoon")
 
 	mariadbConnectionStr = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", mariadbUser, mariadbPassword, mariadbHost, mariadbPort, mariadbDatabase)
 	log.Print(fmt.Sprintf("Using %s as the connstring", mariadbConnectionStr))

--- a/mariadb.go
+++ b/mariadb.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	_ "github.com/go-sql-driver/mysql"
 	machineryEnvVars "github.com/uselagoon/machinery/utils/variables"
 	"log"
 	"net/http"
@@ -16,8 +17,8 @@ var (
 )
 
 func mariadbHandler(w http.ResponseWriter, r *http.Request) {
-	mariadbPath := r.URL.Path
-	localService, lagoonService := cleanRoute(mariadbPath)
+	service := r.URL.Query().Get("service")
+	localService, lagoonService := cleanRoute(service)
 	mariadbUser := machineryEnvVars.GetEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
 	mariadbPassword := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
 	mariadbHost := machineryEnvVars.GetEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)

--- a/mongo.go
+++ b/mongo.go
@@ -24,8 +24,8 @@ var (
 )
 
 func mongoHandler(w http.ResponseWriter, r *http.Request) {
-	mongoPath := r.URL.Path
-	localService, lagoonService := cleanRoute(mongoPath)
+	service := r.URL.Query().Get("service")
+	localService, lagoonService := cleanRoute(service)
 	mongoUser := machineryEnvVars.GetEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
 	mongoPassword := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
 	mongoHost = machineryEnvVars.GetEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)

--- a/mongo.go
+++ b/mongo.go
@@ -27,7 +27,7 @@ func mongoHandler(w http.ResponseWriter, r *http.Request) {
 	localService, lagoonService := cleanRoute(service)
 	mongoUser := getEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
 	mongoPassword := getEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
-	mongoHost := getEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)
+	mongoHost = getEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)
 	mongoPort := getEnv(fmt.Sprintf("%s_PORT", lagoonService), "27017")
 	mongoDatabase := getEnv(fmt.Sprintf("%s_DATABASE", lagoonService), "lagoon")
 

--- a/mongo.go
+++ b/mongo.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	machineryEnvVars "github.com/uselagoon/machinery/utils/variables"
 	"log"
 	"net/http"
 	"os"
@@ -23,13 +24,13 @@ var (
 )
 
 func mongoHandler(w http.ResponseWriter, r *http.Request) {
-	service := r.URL.Query().Get("service")
-	localService, lagoonService := cleanRoute(service)
-	mongoUser := getEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
-	mongoPassword := getEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
-	mongoHost = getEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)
-	mongoPort := getEnv(fmt.Sprintf("%s_PORT", lagoonService), "27017")
-	mongoDatabase := getEnv(fmt.Sprintf("%s_DATABASE", lagoonService), "lagoon")
+	mongoPath := r.URL.Path
+	localService, lagoonService := cleanRoute(mongoPath)
+	mongoUser := machineryEnvVars.GetEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
+	mongoPassword := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
+	mongoHost = machineryEnvVars.GetEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)
+	mongoPort := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PORT", lagoonService), "27017")
+	mongoDatabase := machineryEnvVars.GetEnv(fmt.Sprintf("%s_DATABASE", lagoonService), "lagoon")
 
 	if mongoHost != localService {
 		mongoConnectionStr = fmt.Sprintf("mongodb://%s:%s@%s:%s/%s", mongoUser, mongoPassword, mongoHost, mongoPort, mongoDatabase)

--- a/opensearch.go
+++ b/opensearch.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	machineryEnvVars "github.com/uselagoon/machinery/utils/variables"
 	"log"
 	"net/http"
 	"os"
@@ -17,7 +18,8 @@ import (
 )
 
 var (
-	opensearchHost string
+	opensearchHost          = machineryEnvVars.GetEnv("OPENSEARCH_HOST", "opensearch-2")
+	opensearchConnectionStr = fmt.Sprintf("http://%s:9200", opensearchHost)
 )
 
 func opensearchHandler(w http.ResponseWriter, r *http.Request) {

--- a/opensearch.go
+++ b/opensearch.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	machineryEnvVars "github.com/uselagoon/machinery/utils/variables"
 	"log"
 	"net/http"
 	"os"
@@ -18,8 +17,7 @@ import (
 )
 
 var (
-	opensearchHost          = machineryEnvVars.GetEnv("OPENSEARCH_HOST", "opensearch-2")
-	opensearchConnectionStr = fmt.Sprintf("http://%s:9200", opensearchHost)
+	opensearchHost string
 )
 
 func opensearchHandler(w http.ResponseWriter, r *http.Request) {

--- a/persistentstorage.go
+++ b/persistentstorage.go
@@ -10,7 +10,7 @@ import (
 )
 
 func persistentStorageHandler(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.RawQuery
+	path := r.URL.Query().Get("path")
 	fmt.Fprintf(w, persistentStorageConnector(path))
 }
 

--- a/persistentstorage.go
+++ b/persistentstorage.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"os"
+)
+
+func persistentStorageHandler(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.RawQuery
+	fmt.Fprintf(w, persistentStorageConnector(path))
+}
+
+func persistentStorageConnector(route string) string {
+	if route != os.Getenv("STORAGE_LOCATION") {
+		return "Storage location is not defined - ensure format matches '/storage?path'"
+	}
+	path := route + "/storage.txt"
+	f, err := os.Create(path)
+	if err != nil {
+		log.Println(err)
+	}
+
+	for _, e := range os.Environ() {
+		_, err := f.WriteString(strconv.Quote(e) + "\n")
+		if err != nil {
+			log.Print(err)
+		}
+		e := f.Sync()
+		if e != nil {
+			log.Print(e)
+		}
+	}
+
+	fileBuffer, err := os.ReadFile(path)
+	var results = string(fileBuffer)
+	return results
+}

--- a/persistentstorage.go
+++ b/persistentstorage.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
+	machineryEnvVars "github.com/uselagoon/machinery/utils/variables"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
-
-	"os"
 )
 
 func persistentStorageHandler(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +17,7 @@ func persistentStorageHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func persistentStorageConnector(route string) string {
-	if route != os.Getenv("STORAGE_LOCATION") {
+	if route != machineryEnvVars.GetEnv("STORAGE_LOCATION", "") {
 		return "Storage location is not defined - ensure format matches '/storage?path=[path]'"
 	}
 	path := route + "/storage.txt"

--- a/postgres.go
+++ b/postgres.go
@@ -19,8 +19,8 @@ var (
 )
 
 func postgresHandler(w http.ResponseWriter, r *http.Request) {
-	postgresPath := r.URL.Path
-	localService, lagoonService := cleanRoute(postgresPath)
+	service := r.URL.Query().Get("service")
+	localService, lagoonService := cleanRoute(service)
 	postgresUser := machineryEnvVars.GetEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
 	postgresPassword := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
 	postgresHost := machineryEnvVars.GetEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)

--- a/postgres.go
+++ b/postgres.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	machineryEnvVars "github.com/uselagoon/machinery/utils/variables"
 	"log"
 	"net/http"
 	"os"
@@ -18,13 +19,13 @@ var (
 )
 
 func postgresHandler(w http.ResponseWriter, r *http.Request) {
-	service := r.URL.Query().Get("service")
-	localService, lagoonService := cleanRoute(service)
-	postgresUser := getEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
-	postgresPassword := getEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
-	postgresHost := getEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)
-	postgresPort := getEnv(fmt.Sprintf("%s_PORT", lagoonService), "5432")
-	postgresDatabase := getEnv(fmt.Sprintf("%s_DATABASE", lagoonService), "lagoon")
+	postgresPath := r.URL.Path
+	localService, lagoonService := cleanRoute(postgresPath)
+	postgresUser := machineryEnvVars.GetEnv(fmt.Sprintf("%s_USERNAME", lagoonService), "lagoon")
+	postgresPassword := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PASSWORD", lagoonService), "lagoon")
+	postgresHost := machineryEnvVars.GetEnv(fmt.Sprintf("%s_HOST", lagoonService), localService)
+	postgresPort := machineryEnvVars.GetEnv(fmt.Sprintf("%s_PORT", lagoonService), "5432")
+	postgresDatabase := machineryEnvVars.GetEnv(fmt.Sprintf("%s_DATABASE", lagoonService), "lagoon")
 
 	postgresConnectionStr = fmt.Sprintf("user=%s password=%s dbname=%s sslmode=%s host=%s port=%s", postgresUser, postgresPassword, postgresDatabase, postgresSSL, postgresHost, postgresPort)
 	log.Print(fmt.Sprintf("Using %s as the connstring", postgresConnectionStr))


### PR DESCRIPTION
Adresses #15 - Writes Environment variables to the defined storage location in docker-compose and displays the filtered results.
The storage location is defined via the url using a new, more verbose, format - `/storage?path=[ path ]` - new format to be applied to all service tests via PR #16.