### PR TITLE
Change: Updates the router handler to handle panic on incorrect service

### DIFF
--- a/TESTING_dockercompose.md
+++ b/TESTING_dockercompose.md
@@ -57,7 +57,7 @@ docker compose exec -T commons sh -c "curl -kL http://go-web:3000/opensearch?ser
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/opensearch?service=opensearch-2" | grep "LAGOON_TEST_VAR=internal-services-test"
 
 # mongo-4 should be able to read/write data
-docker compose exec -T commons sh -c "curl -kL http://go-web:3000/mongo?service=mongo-4" | grep "SERVICE_HOST="
+docker compose exec -T commons sh -c "curl -kL http://go-web:3000/mongo?service=mongo-4" | grep "SERVICE_HOST=mongo-4"
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/mongo?service=mongo-4" | grep "LAGOON_TEST_VAR=internal-services-test"
 
 # redis-6 should be able to read/write data
@@ -75,6 +75,9 @@ docker compose exec -T commons sh -c "curl -kL http://go-web:3000/solr?service=s
 # persistent storage should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/storage?path=/app/files" | grep "STORAGE_PATH=/app/files/storage.txt"
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/storage?path=/app/files" | grep "LAGOON_TEST_VAR=internal-services-test"
+
+# Incorrect service should be caught & error output
+docker compose exec -T commons sh -c "curl -kL http://go-web:3000/mariadb?service=incorrect-service" | grep "mariadb is not a compatible driver with service: incorrect-service"
 ```
 
 Destroy tests

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"time"
 )
 
 type funcType func() map[string]string
@@ -24,16 +23,21 @@ func main() {
 	r.HandleFunc("/", handleReq)
 	http.Handle("/", r)
 
-	log.Fatal(http.ListenAndServe(":3000", timeoutHandler(r)))
+	log.Fatal(http.ListenAndServe(":3000", handler(r)))
 }
 
-func timeoutHandler(m *mux.Router) http.HandlerFunc {
+func handler(m *mux.Router) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		driver := strings.ReplaceAll(r.URL.Path, "/", "")
-		service := r.URL.Query().Get("service")
-		incompatibleError := fmt.Sprintf("%s is not a compatible driver with service: %s", driver, service)
-		timeoutHandler := http.TimeoutHandler(m, 3*time.Second, incompatibleError)
-		timeoutHandler.ServeHTTP(w, r)
+		defer func() {
+			driver := strings.ReplaceAll(r.URL.Path, "/", "")
+			service := r.URL.Query().Get("service")
+			incompatibleError := fmt.Sprintf("%s is not a compatible driver with service: %s", driver, service)
+			if err := recover(); err != nil {
+				http.Error(w, incompatibleError, http.StatusInternalServerError)
+			}
+		}()
+		handler := http.Handler(m)
+		handler.ServeHTTP(w, r)
 	}
 }
 

--- a/opensearch.go
+++ b/opensearch.go
@@ -57,13 +57,13 @@ func cleanOpensearchOutput(sr *opensearchapi.SearchResp) string {
 
 func createOpensearchIndexDocument(client *opensearchapi.Client) {
 	settings := strings.NewReader(`{
-		'settings': {
-			'index': {
-				'number_of_shards': 1,
-				'number_of_replicas': 0
-				}
+		"settings": {
+			"index": {
+				"number_of_shards": 1,
+				"number_of_replicas": 0
 			}
-		}`)
+		}
+	}`)
 
 	_, err := client.Indices.Create(
 		ctx,


### PR DESCRIPTION
Currently the `http` library panics on `ServeHTTP` when an incorrect service is provided. This reworks the router handler function to handle panics on incorrect service and display relevant messaging. Includes a basic test