### PR TITLE
Implements valkey service

### DIFF
--- a/TESTING_dockercompose.md
+++ b/TESTING_dockercompose.md
@@ -32,6 +32,7 @@ docker run --rm --net internal-services-test_default jwilder/dockerize dockerize
 docker run --rm --net internal-services-test_default jwilder/dockerize dockerize -wait tcp://mongo-4:27017 -timeout 1m
 docker run --rm --net internal-services-test_default jwilder/dockerize dockerize -wait tcp://redis-6:6379 -timeout 1m
 docker run --rm --net internal-services-test_default jwilder/dockerize dockerize -wait tcp://redis-7:6379 -timeout 1m
+docker run --rm --net internal-services-test_default jwilder/dockerize dockerize -wait tcp://valkey-8:6379 -timeout 1m
 docker run --rm --net internal-services-test_default jwilder/dockerize dockerize -wait tcp://solr-8:8983 -timeout 1m
 docker run --rm --net internal-services-test_default jwilder/dockerize dockerize -wait tcp://solr-9:8983 -timeout 1m
 
@@ -73,6 +74,10 @@ docker compose exec -T commons sh -c "curl -kL http://go-web:3000/redis?service=
 # redis-7 should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/redis?service=redis-7" | grep "SERVICE_HOST=redis-7"
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/redis?service=redis-7" | grep "LAGOON_TEST_VAR=internal-services-test"
+
+# valkey-8 should be able to read/write data
+docker compose exec -T commons sh -c "curl -kL http://go-web:3000/valkey?service=valkey-8" | grep "SERVICE_HOST=valkey-8"
+docker compose exec -T commons sh -c "curl -kL http://go-web:3000/valkey?service=valkey-8" | grep "LAGOON_TEST_VAR=internal-services-test"
 
 # solr-8 should be able to read/write data
 docker compose exec -T commons sh -c "curl -kL http://go-web:3000/solr?service=solr-8" | grep "SERVICE_HOST=solr-8"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
   valkey-8:
     image: uselagoon/valkey-8:latest
     labels:
-      lagoon.type: redis
+      lagoon.type: valkey
     ports:
       - '6379'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,13 @@ services:
     ports:
       - '6379'
 
+  valkey-8:
+    image: uselagoon/valkey-8:latest
+    labels:
+      lagoon.type: redis
+    ports:
+      - '6379'
+
   solr-8:
     image: uselagoon/solr-8:latest
     labels:

--- a/main.go
+++ b/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 type funcType func() map[string]string
@@ -22,6 +23,7 @@ func main() {
 	r.HandleFunc("/opensearch", opensearchHandler)
 	r.HandleFunc("/storage", persistentStorageHandler)
 	r.HandleFunc("/mysql", mariadbHandler)
+	r.HandleFunc("/valkey", redisHandler)
 	r.HandleFunc("/", handleReq)
 	http.Handle("/", r)
 


### PR DESCRIPTION
Adds the valkey-8 image, valkey service type, and a route redirect to treat valley and redis as the same (for now)

Not to be merged until Lagoon 2.22 is released